### PR TITLE
Changing the python shebang

### DIFF
--- a/CIPP/tos_success.py
+++ b/CIPP/tos_success.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2018, Ross A. Beyer (rbeyer@seti.org)
 # 


### PR DESCRIPTION
At PIRL, `python` may be python 2 or python 3; `python3` always exists and is always python 3. This seems to be how things are done?