### PR TITLE
Latitude exclusion zone correlates with priority and incorporation of WTH priorities

### DIFF
--- a/CIPP/README.rst
+++ b/CIPP/README.rst
@@ -31,11 +31,13 @@ put in, or any other columns that you might have added).
 Working with the HiTList
 ------------------------
 ``prioritize_by_orbit.py`` can be used on the HiTList you get from
-your HiTS to clearly flag (by changing their existing priority from
-positive to negative) which lower-priority observations in each
-orbit are 'excluded' by the latitude-exclusion zone (defaults to
-40 degrees in latitude on either side of an observation) of higher
-priority observations.
+your HiTS (or the PTF you created with ``special_priorities.py``)
+to clearly flag (by changing their existing priority from positive
+to negative) which lower-priority observations in each orbit are
+'excluded' by the latitude-exclusion zone (this latitude zone
+exclusion is 40 degrees on either side of observation for the
+highest priority observations, and decreases with decreasing
+priority).
 
 ``priority_rewrite.py`` can be used near the end of your process when you
 have a bunch of observations that all have the same priority that each need

--- a/CIPP/README.rst
+++ b/CIPP/README.rst
@@ -30,6 +30,20 @@ put in, or any other columns that you might have added).
 
 Working with the HiTList
 ------------------------
+``special_priorities.py`` will modify all of those 11000 priorities
+and spread them out from 11000 to 11400, based on the priorities
+from the Special Target Requests by Cycle page. People have diligently
+entered in priorities from 1 to 10 for those Special Targets (WTHs,
+HiKERs, CaSSIS coordination targets, etc.).  If you would like to
+incorporate those priorities, you can use ``special_priorities.py``
+on the delivered HiTList.ptf to create a new "special.ptf" where
+those records have altered priorities.  This means that once you
+sort by priority everyone's highest rated WTHs will be priority
+11400, and maybe easier to pick between.  Similarly, with this
+priority modification in place, you you can compare two of these
+that might fall in the same orbit, just by looking at their (now modified)
+priority value.
+
 ``prioritize_by_orbit.py`` can be used on the HiTList you get from
 your HiTS (or the PTF you created with ``special_priorities.py``)
 to clearly flag (by changing their existing priority from positive

--- a/CIPP/prioritize_by_orbit.py
+++ b/CIPP/prioritize_by_orbit.py
@@ -1,21 +1,27 @@
 #!/usr/bin/env python
 """Scans a PTF, grouping records by orbit, and attempts to deconflict
-   observations in that orbit.
+observations in that orbit.
 
-   This is NOT a substitute for reviewing the PTF yourself.
+This is NOT a substitute for reviewing the PTF yourself.
 
-   The algorithm will examine each orbit (based on the PTF Orbit Number
-   field, ignoring any Orbit Alternatives), and will guarantee that
-   at most, only the user-specified number of observations will remain
-   as positive priorities after it runs, all other records will be set
-   to negative priorities (allowing inspection afterwards).
+The algorithm will examine each orbit (based on the PTF Orbit Number
+field, ignoring any Orbit Alternatives), and will guarantee that
+at most, only the user-specified number of observations will remain
+as positive priorities after it runs, all other records will be set
+to negative priorities (allowing inspection afterwards).
 
-   For each orbit, the alrgorithm will begin with the highest
-   prioritized observation, and deprioritize any observations within
-   the latitude exclusion range in either direction, then find the
-   next highest, and so on.  When faced with observations that have
-   the same priority, it will give preference to the observation
-   that is closest to the equator.
+For each orbit, the algorithm will begin with the highest
+prioritized observation, and deprioritize any observations within
+the latitude exclusion range in either direction, then find the
+next highest, and so on.  When faced with observations that have
+the same priority, it will give preference to the observation
+that is closest to the equator.
+
+The "half-width" of the latitude exclusion zone is 40 degrees for
+SPORC stereo-2s and above (14600), then 30 degrees for priorities
+from there through the 2nd half stereos (13000), then 20 degrees
+through the easier-to-get WTHs, stereo 1s, HiKERs, and high priority
+non-WTH targets (10000), and then 15 degrees for priorities below that.
 """
 
 # Copyright 2020, Ross A. Beyer (rbeyer@seti.org)
@@ -33,17 +39,21 @@
 # limitations under the License.
 #
 # TODO: write in a mechanism that allows the user to optimize for more
-# observations per orbit, rather than strictly giving the highest priority
-# plus the lowest latitude the top spot.  Doing so may 'exclude' two other
-# observations, and if one had the same priority, but didn't 'exclude' the
-# other, you might be able to fit more observations on an orbit.
+#   observations per orbit, rather than strictly giving the highest priority
+#   plus the lowest latitude the top spot.  Doing so may 'exclude' two other
+#   observations, and if one had the same priority, but didn't 'exclude' the
+#   other, you might be able to fit more observations on an orbit.
 #
 # TODO: may also want something other than abs(latitude) to be a driver,
-# possibly time since coming out of eclipse or something.  Lots of
-# possibilities.
+#   possibly time since coming out of eclipse or something.  Lots of
+#   possibilities.
+#
+# TODO: If we really want to get fancy, implement a way to have a
+#   user-specified half_widths list.
 
 import argparse
 import logging
+import sys
 
 from itertools import groupby
 
@@ -51,32 +61,42 @@ import priority_rewrite as pr
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('-o', '--output', required=False)
-    parser.add_argument('--per_orbit', required=False, default=4,
-                        help="The number of observations to keep in"
-                             "an orbit.")
-    parser.add_argument('--latitude_exclude', required=False, default=40,
-                        help="The amount of latitude on either side "
-                             "(so it is a half-width) of an observation "
-                             "that will be excluded for consideration.")
-    parser.add_argument('-n', '--dry_run', required=False,
-                        action='store_true', help='Perform the rearranging '
-                        'but do not write out results.')
-    parser.add_argument('in_file', help="a .ptf or .csv file")
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("-o", "--output", required=False)
+    parser.add_argument(
+        "--per_orbit",
+        required=False,
+        default=4,
+        type=int,
+        help="The max number of observations to keep in an orbit.",
+    )
+    parser.add_argument(
+        "-n",
+        "--dry_run",
+        required=False,
+        action="store_true",
+        help="Perform the rearranging but do not write out results.",
+    )
+    parser.add_argument("in_file", help="a .ptf or .csv file")
 
     args = parser.parse_args()
 
-    logging.basicConfig(format='%(levelname)s: %(message)s')
+    logging.basicConfig(format="%(levelname)s: %(message)s")
 
     ptf_in = pr.get_input(args.in_file)
 
-    new_ptf_records = prioritize_by_orbit(ptf_in,
-                                          args.per_orbit,
-                                          args.latitude_exclude)
+    # half-widths are a list of two-tuples, the first position is a
+    # priority value, and the second is a latitude half-width.
+    # the final two-tuple should be (0, 0).
+    half_widths = ((17000, 40), (14600, 30), (13000, 20), (10000, 15), (0, 0))
+
+    new_ptf_records = prioritize_by_orbit(ptf_in, half_widths, args.per_orbit)
 
     # This sorting ignores the 'a' or 'd' markers on Orbits.
-    new_ptf_records.sort(key=lambda x: int(x['Orbit Number'][:-1]))
+    new_ptf_records.sort(key=lambda x: int(x["Orbit Number"][:-1]))
 
     if args.dry_run:
         pass
@@ -87,14 +107,25 @@ def main():
 
 
 class intervals(object):
-
-    def __init__(self, half_width: float):
+    """Manages the intervals described by the latitude exclusion zones.
+    """
+    def __init__(self, half_widths=None):
         self.intervals = list()  # a list of two-tuples
-        self.half_width = float(half_width)
+        if half_widths is None:
+            self.half_widths = ((sys.maxsize, 40), (0, 0))
+        else:
+            if half_widths[-1][0] != 0:
+                half_widths.append((0, 0))
 
-    def add(self, point: float):
+            self.half_widths = half_widths
+
+    def add(self, point: float, priority=None):
+        """Adds an interval centered on *point* whose boundaries
+        are derived from the *priority* value.
+        """
         p = float(point)
-        new_interval = ((p - self.half_width), (p + self.half_width))
+        hw = self.get_half_width(priority)
+        new_interval = ((p - hw), (p + hw))
         intervals = self.intervals + [new_interval]
 
         # This interval merging logic is from
@@ -119,44 +150,71 @@ class intervals(object):
         self.intervals = merged
         return
 
+    def get_half_width(self, priority=None):
+        """Returns the half-width given the *priority* value.
+
+        If *priority* is not given, the first half-width in this
+        object's half_widths will be used.
+        """
+        if priority is None:
+            return self.half_widths[0][1]
+        else:
+            for i in range(len(self.half_widths) - 1):
+                if (
+                    self.half_widths[i][0]
+                    > priority
+                    >= self.half_widths[i + 1][0]
+                ):
+                    return self.half_widths[i][1]
+
+            raise ValueError(
+                f"The priority ({priority}) is not in the range "
+                f"({self.half_widths[-1][0]}, {self.half_widths[0][0]})."
+            )
+
     def is_in(self, point: float):
+        """Returns True if the given value is within (inclusive) the
+        boundaries of one of this object's intervals.  False otherwise.
+        """
         p = float(point)
         for i in self.intervals:
-            if p >= i[0] and p <= i[1]:
+            if i[0] <= p <= i[1]:
                 return True
         else:
             return False
 
 
-def prioritize_by_orbit(records: list, observations=4,
-                        latitude_exclude=40) -> list:
-    '''Rewrites priorities by orbit.'''
+def prioritize_by_orbit(records: list, half_widths, observations=4,) -> list:
+    """Rewrites priorities by orbit."""
 
     new_records = list()
-    sorted_by_o = sorted(records,
-                         key=lambda x: int(x['Orbit Number'][:-1]))
-    for orbit, g in groupby(sorted_by_o,
-                            key=lambda x: int(x['Orbit Number'][:-1])):
-        exclude = intervals(latitude_exclude)
+    sorted_by_o = sorted(records, key=lambda x: int(x["Orbit Number"][:-1]))
+    for orbit, g in groupby(
+        sorted_by_o, key=lambda x: int(x["Orbit Number"][:-1])
+    ):
+        exclude = intervals(half_widths)
         obs_count = 0
         by_orbit = list(g)
-        by_orbit.sort(key=lambda x: int(x['Request Priority']), reverse=True)
-        for pri, pri_g in groupby(by_orbit,
-                                  key=lambda x: int(x['Request Priority'])):
+        by_orbit.sort(key=lambda x: int(x["Request Priority"]), reverse=True)
+        for pri, pri_g in groupby(
+            by_orbit, key=lambda x: int(x["Request Priority"])
+        ):
             recs = list(pri_g)
             if len(recs) != 1:
                 # need to prioritize these by latitude
                 recs = pr.priority_rewrite(recs, keepzero=True)
 
-            for r in sorted(recs, key=lambda x: int(x['Request Priority']),
-                            reverse=True):
-                if(obs_count < observations and
-                   not exclude.is_in(r['Latitude'])):
-                    exclude.add(r['Latitude'])
+            for r in sorted(
+                recs, key=lambda x: int(x["Request Priority"]), reverse=True
+            ):
+                if obs_count < observations and not exclude.is_in(
+                    r["Latitude"]
+                ):
+                    exclude.add(r["Latitude"], int(r["Request Priority"]))
                     obs_count += 1
-                    r['Request Priority'] = pri
+                    r["Request Priority"] = pri
                 else:
-                    r['Request Priority'] = -1 * pri
+                    r["Request Priority"] = -1 * pri
 
                 new_records.append(r)
 

--- a/CIPP/special_priorities.py
+++ b/CIPP/special_priorities.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""Takes one or more text files that contain special targets, and scans a
+PTF, looking for targets with a certain priority, and modifies them based on
+priorities from the special targets.
+
+This is NOT a substitute for reviewing the PTF yourself.
+
+The algorithm will examine each target in the PTF which has a
+priority of 11000, and will see if that target is in any of the
+special target text files (which can just be text copy and pasted
+from the wiki). If it is and there is a priority there, the
+priority is combined with 11000 as follows: the priority
+is multiplied by 10, and added to 11300. So a 10 becomes 11400,
+a 6 becomes 11360, a 2 becomes 11320, etc.
+"""
+
+# Copyright 2020, Ross A. Beyer (rbeyer@seti.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import csv
+import logging
+import os
+
+import priority_rewrite as pr
+import ptf
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Will report additional information.",
+    )
+    parser.add_argument("-o", "--output", required=False)
+    parser.add_argument(
+        "-p", "--ptf", required=True, help="a .ptf or .csv file"
+    )
+    parser.add_argument(
+        "wth", nargs="+", help="File(s) with text copied from WTH list."
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(levelname)s: %(message)s", level=(30 - 10 * args.verbose)
+    )
+
+    ptf_in = pr.get_input(args.ptf)
+
+    specials = {}
+    for f in args.wth:
+        specials.update(get_special_priorities(f))
+
+    new_ptf_records = apply_priorities(ptf_in, 11000, specials)
+
+    out_str = pr.write_output(ptf_in, new_ptf_records, args.output)
+    if out_str:
+        print(out_str)
+
+
+def get_special_priorities(path: os.PathLike) -> dict:
+    """Returns a dict whose keys are suggestion IDs, and
+    whose values are integer priorities.
+
+    The *path* file can be any CSV-type file, blank lines are
+    ignored, the first entry on each "real" line is taken to be
+    the suggesion ID, and the second item is assumed to be a
+    priority and converted to an integer.
+    """
+    d = {}
+    with open(path, newline="", encoding=ptf.guess_encoding(path)) as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if row:
+                d[row[0]] = int(row[1])
+    return d
+
+
+def apply_priorities(records: list, basepriority: int, specials: dict):
+    """For each item in *records* that has *basepriority*, its suggestion
+    number is checked for in *specials*.  If present, the priority of the
+    item in *records* is modified.
+
+    The priority is modified as follows, the special priority is multiplied
+    by 10 and added to *basepriority* + 300.
+    """
+
+
+    new_records = list()
+
+    for r in records:
+        if r["Team Database ID"] in specials:
+            if basepriority == int(r["Request Priority"]):
+                sp_pri = specials[r["Team Database ID"]]
+                orig_pri = int(r["Request Priority"])
+                if 1 <= sp_pri <= 10:
+                    r["Request Priority"] = orig_pri + 300 + (sp_pri * 10 )
+                else:
+                    raise ValueError(
+                        f"The priority from the special file ({sp_pri}) is "
+                        "not an integer between 1 and 10, inclusive."
+                    )
+                logging.info(
+                    f"{r['Team Database ID']} was {orig_pri} "
+                    f"is now {r['Request Priority']}"
+                )
+            else:
+                logging.warning(
+                    f"WTH {r['Team Database ID']} has a priority "
+                    f"of {r['Request Priority']}, FWIW.")
+
+        new_records.append(r)
+
+    return new_records
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
prioritize_by_orbit: Updated to have a scaled latitude exclusion zone based on priority, such that lower priority targets have smaller exclusion zones.  The idea here is that a later, lower-priority observation might be able to sneak past TOS, where a higher priority one probably won't.

special_priorities: Added this tool that incorporates suggested priorities for targets from the Special Target Requests wiki page (since people do actually prioritize them from 1 to 10 there).