### PR TITLE
Cycle392improvements

### DIFF
--- a/CIPP/csv2ptf.py
+++ b/CIPP/csv2ptf.py
@@ -29,6 +29,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-o', '--output', required=False, default='.ptf')
     parser.add_argument('-p', '--ptf', required=True)
+    parser.add_argument('-t', '--truncate', required=False, type=int)
     parser.add_argument('csv', metavar="some.csv-file")
 
     args = parser.parse_args()
@@ -60,6 +61,9 @@ def main():
 
     new_ptf['USERNAME'] = getpass.getuser()
     new_ptf['CREATION_DATE'] = datetime.utcnow().strftime('%Y-%jT%H:%M:%S')
+
+    if args.truncate:
+        new_ptf = new_ptf[:args.truncate]
 
     ptfout_path = ''
     if args.output.startswith('.'):

--- a/CIPP/ptf.py
+++ b/CIPP/ptf.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import collections.abc
+import copy
 import csv
 import io
 import os
@@ -101,13 +102,21 @@ class PTF(collections.abc.Sequence):
         return len(self.ptf_recs)
 
     def __getitem__(self, key):
-        try:
-            return self.dictionary[key]
-        except KeyError:
-            return self.ptf_recs[key]
+        if isinstance(key, slice):
+            sliced = copy.deepcopy(self)
+            sliced.ptf_recs = sliced.ptf_recs[key]
+            return sliced
+        else:
+            try:
+                return self.dictionary[key]
+            except KeyError:
+                return self.ptf_recs[key]
 
     def __setitem__(self, key, value):
-        self.dictionary[key] = value
+        if isinstance(key, slice):
+            self.ptf_recs[key] = value
+        else:
+            self.dictionary[key] = value
         return
 
     def __iter__(self):


### PR DESCRIPTION
I suspect I'm the only one that uses these, but here are some improvements:

- case-independent key matching (sometimes "Request Priority," sometimes "Request priority," now both work)
- Proper SPORC pair removal.  If one half of a SPORC pair is unable to be prioritized, the other is now properly deprioritized (given a negative priority).
- Added slice notation capabilities to the PTF object
- Which enables a --truncate option on csv2ptf.py to restrict the output PTF to some number of records.