### PR TITLE
Fixes error with certain formats

### DIFF
--- a/CIPP/ptf.py
+++ b/CIPP/ptf.py
@@ -321,7 +321,7 @@ def load(ptf_path: os.PathLike) -> PTF:
               encoding=guess_encoding(ptf_path)) as f:
         ptf_str = f.read()
 
-    return loads(ptf_str)
+    return loads(ptf_str.lstrip(u'\ufeff'))
 
 
 def guess_encoding(path):


### PR DESCRIPTION
Turns out that the file that Susan was working with was encoded in such a way that when Python read it in, the text began with a [Byte Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark) (BOM).  This prevented the `ptf.py` module from recognizing the text as a PTF file, and the programs then fell back to trying to interpret it as a plain CSV file, which it wasn't.

Susan reported that when changing the capitalization of the commented header columns that the program worked.  I suspect this is because whatever she used to make that edit then wrote out a file without a leading BOM.  If I very carefully just changed "Orbit number" to "Orbit Number" without changing any other bytes in the file, I still got the error.

This PR just makes `ptf.load()` check the string before it is passed along to `ptf.loads()` and strips off a BOM if it is there.