### PR TITLE
460 changes

### DIFF
--- a/CIPP/prioritize_by_orbit.py
+++ b/CIPP/prioritize_by_orbit.py
@@ -356,7 +356,7 @@ def prioritize_by_orbit(
                                         f"{r['Team Database ID']} would have been "
                                         f"observation #{observations} in orbit "
                                         f"{orbit} and was given priority "
-                                        f"r['Request Priority']."
+                                        f"{r['Request Priority']}."
                                     )
                                 else:
                                     logger.info(

--- a/CIPP/priority_rewrite.py
+++ b/CIPP/priority_rewrite.py
@@ -89,9 +89,8 @@ def priority_rewrite(records, reset_str=None, keepzero=False) -> list:
 
         if is_enough_space(pri, next_pri, count[pri]):
             for j, r in enumerate(pri_records):
-                d = collections.OrderedDict(r)
-                d['Request Priority'] = pri + j
-                new_records.append(d)
+                r['Request Priority'] = pri + j
+                new_records.append(r)
         else:
             logging.warning('Starting at {} we need {} spots, but the next '
                             'priority is {}.'.format(pri,
@@ -100,8 +99,7 @@ def priority_rewrite(records, reset_str=None, keepzero=False) -> list:
             logging.warning('\tLeaving these {} as identical priority '
                             '{}.'.format(count[pri], pri))
             for r in pri_records:
-                d = collections.OrderedDict(r)
-                new_records.append(d)
+                new_records.append(r)
     return new_records
 
 

--- a/CIPP/test_tos_success.py
+++ b/CIPP/test_tos_success.py
@@ -46,7 +46,7 @@ def my_mock_open(read_data):
 class TestFunctions(unittest.TestCase):
 
     def test_get_wths(self):
-        m = my_mock_open(read_data='''1234, WTH priority, This, has, commas
+        m = my_mock_open(read_data='''1234, This, has, commas
 567,
 890''')
         with patch('tos_success.open', m):


### PR DESCRIPTION
Discovered some issues during application to cycle 460:

Fixed: PTFDict items were being converted to OrderedDicts which broke their case-independent key use expected by the rest of the modules.

There was a typo in one of the tests, and a variable was not properly quoted in a log statement, but these were minor.